### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "",
   "main": "",
   "scripts": {
-    "dev": "live-server --watch=src,examples"
+    "dev": "./bin/node_modules/live-server --watch=src,examples"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "three": "^0.87.1",
     "three-bas": "^2.2.0"
+  },
+  "devDependencies": {
+    "live-server": "^1.2.0",
   }
 }


### PR DESCRIPTION
having many projects that require a global install of a module may result in issues, as projects may become outdated and expect a different version

using a local-install will also prevent other developers from running into a 'module not found' error for those who don't already have live-server installed